### PR TITLE
Support 8bpp bitmaps when prepending the BITMAPFILEHEADER structure to the bitmap data during resource load.

### DIFF
--- a/PELoaderLib/BitmapFileHeader.cs
+++ b/PELoaderLib/BitmapFileHeader.cs
@@ -9,14 +9,9 @@ using System.Text;
 
 namespace PELoaderLib
 {
-    public enum BitmapVersion
-    {
-        BitmapInfoHeader = BitmapFileHeader.BMP_INFO_HEADER_SIZE,
-        BitmapV3InfoHeader = BitmapFileHeader.BMP_INFO_HEADER_SIZE_V3
-    }
-
     internal struct BitmapFileHeader
     {
+        internal const int BMP_CORE_HEADER_SIZE = 12;
         internal const int BMP_FILE_HEADER_SIZE = 14;
         internal const int BMP_INFO_HEADER_SIZE = 40;
         internal const int BMP_INFO_HEADER_SIZE_V3 = 56;
@@ -25,16 +20,34 @@ namespace PELoaderLib
         internal uint bfSize { get; }
         internal short bfReserved1 { get; }
         internal short bfReserved2 { get; }
-        internal uint bfOffBits { get { return BMP_FILE_HEADER_SIZE + (uint)Version; } }
-        internal BitmapVersion Version { get; }
+        internal uint bfOffBits { get { return BMP_FILE_HEADER_SIZE + HeaderSize + PaletteSize; } }
+        internal uint HeaderSize { get; }
+        internal uint PaletteSize { get; }
 
-        internal BitmapFileHeader(BitmapVersion version, uint size)
+        internal BitmapFileHeader(uint size, byte[] headerBytes)
             : this()
         {
-            Version = version;
             bfSize = size;
-
             bfType = MakeType();
+
+            HeaderSize = (uint)headerBytes.Length;
+
+            var depth = BitConverter.ToInt16(headerBytes, HeaderSize == BMP_CORE_HEADER_SIZE ? 10 : 14);
+
+            // todo: support compression modes and color palettes
+            if (depth < 16)
+            {
+                var numColors = HeaderSize > BMP_CORE_HEADER_SIZE
+                    ? BitConverter.ToInt32(headerBytes, 32)
+                    : 0;
+                if (numColors == 0)
+                {
+                    numColors = 1 << depth;
+                }
+
+                var paletteElementSize = HeaderSize == BMP_CORE_HEADER_SIZE ? 3 : 4;
+                PaletteSize = (uint)(numColors * paletteElementSize);
+            }
         }
 
         internal byte[] ToByteArray()

--- a/PELoaderLib/IPEFile.cs
+++ b/PELoaderLib/IPEFile.cs
@@ -18,6 +18,6 @@ namespace PELoaderLib
         OptionalFileHeader OptionalHeader { get; }
 
         void Initialize();
-        byte[] GetEmbeddedBitmapResourceByID(int intResource, BitmapVersion version = BitmapVersion.BitmapInfoHeader, int cultureID = 0);
+        byte[] GetEmbeddedBitmapResourceByID(int intResource, int cultureID = 0);
     }
 }


### PR DESCRIPTION
Remove Bitmap Version flag since it is now calculated dynamically